### PR TITLE
Replace hardcoded MySQL connection strings with environment variables

### DIFF
--- a/flask_app/config/mysqlconnection.py
+++ b/flask_app/config/mysqlconnection.py
@@ -1,10 +1,11 @@
+import os
 import pymysql.cursors
 
 class MySQLConnection:
     def __init__(self,db):
-        connection = pymysql.connect(host='localhost',
-                                    user = 'root',
-                                    password='rootroot',
+        connection = pymysql.connect(host=os.environ["MYSQL_HOST"],
+                                    user = os.environ["MYSQL_USER"],
+                                    password=os.environ["MYSQL_PASSWORD"],
                                     db=db,
                                     charset = 'utf8mb4',
                                     cursorclass = pymysql.cursors.DictCursor,


### PR DESCRIPTION
In all environments (for example: local development environment, production AWS environment, etc), three new environment variables will need to be set on the system as the app starts:

1. `MYSQL_HOST`
2. `MYSQL_USER`
3. `MYSQL_PASSWORD`

Strongly recommended that in any public environments (such as on AWS), the password for any existing MySQL server is rotated, because the current password (`rootroot`) already exists in this history of this public GitHub repository.